### PR TITLE
Fix os-specific path keys

### DIFF
--- a/internal/box/generator.go
+++ b/internal/box/generator.go
@@ -52,7 +52,7 @@ func main() {
 
 	// Walking through embed directory
 	err := filepath.Walk(embedFolder, func(path string, info os.FileInfo, err error) error {
-		relativePath := filepath.ToSlash(strings.TrimPrefix(path, embedFolder))
+		relativePath := filepath.ToSlash(strings.TrimPrefix(path, filepath.FromSlash(embedFolder)))
 
 		if info.IsDir() {
 			// Skip directories


### PR DESCRIPTION
While running the same code on Windows and MacOS I noticed, that my application failed to retrieve my embedded files. 
Given the sample structure from your tutorial you would end up with these lines in your blob.go files:
MacOS = box.Add("/index.html", []byte{...
Windows = box.Add("..\..\static\index.html", []byte{...

This clearly causes issues when later attempting to retrieve "/index.html" in the windows version.